### PR TITLE
Place buttons so that spaces between buttons are equal

### DIFF
--- a/app/src/main/res/layout/activity_imprudent_tweet.xml
+++ b/app/src/main/res/layout/activity_imprudent_tweet.xml
@@ -85,8 +85,8 @@
             android:textColor="#fbfbfe"
             android:textSize="20sp"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintLeft_toLeftOf="@id/goToTwitterAnyApp"
+            app:layout_constraintRight_toRightOf="@id/goToTwitter"
             app:layout_constraintBottom_toBottomOf="parent" />
 
         <Button


### PR DESCRIPTION
Previously, tweet buttons may overlap if display width is too small.

This commit changes layout contraint to make buttons intervals equal.
This would resolve buttons overlap, or at least make it better.

ボタンの重複がなくなるか、少なくともマシになります。

cf. #39

![screenshot_20180724-141005](https://user-images.githubusercontent.com/1246590/43118121-59ad3de2-8f4b-11e8-8634-9505270b6c1d.png)