### PR TITLE
フォーマットを表示するUIが編集時に潰れてしまうのを緩和

### DIFF
--- a/app/src/main/res/layout/activity_imprudent_tweet.xml
+++ b/app/src/main/res/layout/activity_imprudent_tweet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -8,105 +8,87 @@
     android:orientation="vertical"
     tools:context=".ImprudentTweetActivity">
 
-    <TextView
-        android:id = "@+id/imprudenceTweetLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/imprudence_tweet_label"
-        android:textSize="50sp"
-        android:textColor="@color/colorPrimaryDark"
-        android:layout_marginTop="40dp"
-        android:layout_marginBottom="40dp"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <View
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?android:attr/listDivider" />
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:gravity="center">
 
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp" >
+        <TextView
+            android:id = "@+id/imprudenceTweetLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/imprudence_tweet_label"
+            android:textSize="50sp"
+            android:textColor="@color/colorPrimaryDark"
+            android:layout_marginTop="40dp"
+            android:layout_marginBottom="40dp" />
 
         <LinearLayout
             android:id="@+id/ImprudentTweetArea"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:layout_gravity="center_horizontal" >
+            android:layout_gravity="center_horizontal" />
 
-        </LinearLayout>
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-    </ScrollView>
+            <Button
+                android:id="@+id/goToTwitter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="40dp"
+                android:layout_marginBottom="40dp"
+                android:paddingLeft="8dp"
+                android:paddingRight="8dp"
+                android:background="@color/colorAccent"
+                android:onClick="tweet"
+                android:text="@string/web_tweet_button_label"
+                android:textColor="#fbfbfe"
+                android:textSize="20sp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toLeftOf="@id/goToTwitterApp"
+                app:layout_constraintBottom_toBottomOf="parent" />
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?android:attr/listDivider" />
+            <Button
+                android:id="@+id/goToTwitterApp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="40dp"
+                android:layout_marginBottom="40dp"
+                android:paddingLeft="8dp"
+                android:paddingRight="8dp"
+                android:background="@color/colorAccent"
+                android:onClick="tweetByApp"
+                android:text="@string/app_tweet_button_label"
+                android:textColor="#fbfbfe"
+                android:textSize="20sp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintLeft_toLeftOf="@id/goToTwitterAnyApp"
+                app:layout_constraintRight_toRightOf="@id/goToTwitter"
+                app:layout_constraintBottom_toBottomOf="parent" />
 
-    <android.support.constraint.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+            <Button
+                android:id="@+id/goToTwitterAnyApp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="40dp"
+                android:layout_marginBottom="40dp"
+                android:paddingLeft="8dp"
+                android:paddingRight="8dp"
+                android:background="@color/colorAccent"
+                android:onClick="tweetByAnyApp"
+                android:text="@string/share_button_label"
+                android:textColor="#fbfbfe"
+                android:textSize="20sp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintLeft_toRightOf="@+id/goToTwitterApp"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent" />
 
-        <Button
-            android:id="@+id/goToTwitter"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:paddingLeft="8dp"
-            android:paddingRight="8dp"
-            android:background="@color/colorAccent"
-            android:onClick="tweet"
-            android:text="@string/web_tweet_button_label"
-            android:textColor="#fbfbfe"
-            android:textSize="20sp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toLeftOf="@id/goToTwitterApp"
-            app:layout_constraintBottom_toBottomOf="parent" />
-
-        <Button
-            android:id="@+id/goToTwitterApp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:paddingLeft="8dp"
-            android:paddingRight="8dp"
-            android:background="@color/colorAccent"
-            android:onClick="tweetByApp"
-            android:text="@string/app_tweet_button_label"
-            android:textColor="#fbfbfe"
-            android:textSize="20sp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintLeft_toLeftOf="@id/goToTwitterAnyApp"
-            app:layout_constraintRight_toRightOf="@id/goToTwitter"
-            app:layout_constraintBottom_toBottomOf="parent" />
-
-        <Button
-            android:id="@+id/goToTwitterAnyApp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:paddingLeft="8dp"
-            android:paddingRight="8dp"
-            android:background="@color/colorAccent"
-            android:onClick="tweetByAnyApp"
-            android:text="@string/share_button_label"
-            android:textColor="#fbfbfe"
-            android:textSize="20sp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintLeft_toRightOf="@+id/goToTwitterApp"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent" />
-
-    </android.support.constraint.ConstraintLayout>
-
-</LinearLayout>
+        </android.support.constraint.ConstraintLayout>
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
Wrap whole UI with ScrollView to save tweet format area

UI全体をスクロールできるようにして、フォーマットのための領域を確保しました。